### PR TITLE
Refactor data mover init

### DIFF
--- a/src/main/scala/streamer/DataMover.scala
+++ b/src/main/scala/streamer/DataMover.scala
@@ -1,0 +1,193 @@
+package streamer
+
+import chisel3._
+import chisel3.util._
+
+class DataMoverIO(params: DataMoverParams = DataMoverParams()) extends Bundle {
+  // signals for write request address generation
+  val ptr_agu_i = Flipped(Decoupled(UInt(params.addrWidth.W)))
+  val spatialStrides_csr_i = Flipped(
+    Decoupled(Vec(params.spatialDim, UInt(params.addrWidth.W)))
+  )
+
+  // tcdm request ports
+  val tcdm_req = (Vec(
+    params.tcdmPortsNum,
+    Decoupled(new TcdmReq(params.addrWidth, params.tcdmDataWidth))
+  ))
+
+  // from temporal address generation unit to indicate if the transaction is done
+  val done = Input(Bool())
+
+}
+
+class DataMover(params: DataMoverParams = DataMoverParams())
+    extends Module
+    with RequireAsyncReset {
+
+  lazy val io = IO(new DataMoverIO(params))
+
+  // storing the temporal start address when it is valid
+  val ptr_agu = RegInit(0.U(params.addrWidth.W))
+  val start_ptr = WireInit(0.U(params.addrWidth.W))
+
+  // config valid signal for unrolling strides
+  // storing the config when it is valid
+  val config_valid = WireInit(0.B)
+
+  val unrollingStrides = RegInit(
+    VecInit(Seq.fill(params.spatialDim)(0.U(params.addrWidth.W)))
+  )
+
+  val done = WireInit(0.B)
+
+  // original unrolling address for TCDM request
+  val unrolling_addr = WireInit(
+    VecInit(
+      Seq.fill(params.spatialBounds.reduce(_ * _))(0.U(params.addrWidth.W))
+    )
+  )
+
+  // for selecting the real TCDM request address from the original unrolling addresses
+  // according to the tcdmDataWidth and the elementWidth relationship
+  // !!! warning: assuming the data granularity is one tcdmDataWidth
+  // no sub-data accessing within one TCDM bank
+  def packed_addr_num = (params.tcdmDataWidth / 8) / (params.elementWidth / 8)
+
+  // not in the busy with sending current request process
+  val ready_for_new_tcdm_reqs = WireInit(0.B)
+  // data fifo isn't full
+  val can_send_tcdm_req = WireInit(0.B)
+  // tcdm req ready signals
+  val tcdm_req_ready = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
+  val tcdm_req_ready_reg = RegInit(
+    VecInit(Seq.fill(params.tcdmPortsNum)(0.B))
+  )
+  // means transaction success
+  val tcdm_req_all_ready = WireInit(0.B)
+  // means waiting for all the tcdm ports ready (including ready before for this transaction)
+  val wait_for_tcdm_req_all_ready = WireInit(0.B)
+
+  // State declaration
+  val sIDLE :: sBUSY :: Nil = Enum(2)
+  val cstate = RegInit(sIDLE)
+  val nstate = WireInit(sIDLE)
+
+  // Changing states
+  cstate := nstate
+
+  chisel3.dontTouch(cstate)
+  switch(cstate) {
+    is(sIDLE) {
+      when(config_valid) {
+        nstate := sBUSY
+      }.otherwise {
+        nstate := sIDLE
+      }
+
+    }
+    is(sBUSY) {
+      when(done) {
+        nstate := sIDLE
+      }.otherwise {
+        nstate := sBUSY
+      }
+    }
+  }
+
+  config_valid := io.spatialStrides_csr_i.fire
+
+  // store them for later use
+  when(config_valid) {
+    unrollingStrides := io.spatialStrides_csr_i.bits
+  }
+
+  start_ptr := io.ptr_agu_i.bits
+
+  // generating original unrolling address for TCDM request
+  val spatial_addr_gen_unit = Module(
+    new SpatialAddrGenUnit(
+      SpatialAddrGenUnitParams(
+        params.spatialDim,
+        params.spatialBounds,
+        params.addrWidth
+      )
+    )
+  )
+
+  spatial_addr_gen_unit.io.valid_i := cstate =/= sIDLE
+  spatial_addr_gen_unit.io.ptr_i := start_ptr
+  spatial_addr_gen_unit.io.strides_i := unrollingStrides
+  unrolling_addr := spatial_addr_gen_unit.io.ptr_o
+
+  // simulation time address constraint check
+  when(cstate === sBUSY) {
+    for (i <- 0 until params.tcdmPortsNum) {
+      for (j <- 0 until packed_addr_num - 1) {
+        assert(
+          unrolling_addr(i * packed_addr_num + j + 1) === unrolling_addr(
+            i * packed_addr_num + j
+          ) + ((params.tcdmDataWidth / 8) / packed_addr_num).U,
+          "read address in not consecutive in the same bank!"
+        )
+      }
+    }
+  }
+
+  done := io.done
+
+  // needs to be override in extended class!
+  can_send_tcdm_req := cstate === sBUSY
+
+  // assuming addresses are packed in one tcmd request
+  // the data granularity constrain
+  for (i <- 0 until params.tcdmPortsNum) {
+    io.tcdm_req(i).bits.addr := unrolling_addr(i * packed_addr_num)
+  }
+
+  // deal with contention
+  // ensure all the read request are sent successfully
+  for (i <- 0 until params.tcdmPortsNum) {
+    when(can_send_tcdm_req) {
+      when(io.ptr_agu_i.fire) {
+        io.tcdm_req(i).valid := 1.B
+      }.otherwise {
+        io.tcdm_req(i).valid := ~tcdm_req_ready_reg(i)
+      }
+    }.otherwise {
+      io.tcdm_req(i).valid := 0.B
+    }
+  }
+
+  for (i <- 0 until params.tcdmPortsNum) {
+    when(can_send_tcdm_req && !tcdm_req_all_ready) {
+      wait_for_tcdm_req_all_ready := 1.B
+    }.otherwise {
+      wait_for_tcdm_req_all_ready := 0.B
+    }
+  }
+
+  for (i <- 0 until params.tcdmPortsNum) {
+    when(wait_for_tcdm_req_all_ready && !tcdm_req_all_ready) {
+      when(io.tcdm_req(i).ready) {
+        tcdm_req_ready_reg(i) := io.tcdm_req(i).ready
+      }
+    }.otherwise {
+      tcdm_req_ready_reg(i) := 0.B
+    }
+  }
+
+  for (i <- 0 until params.tcdmPortsNum) {
+    tcdm_req_ready(i) := io.tcdm_req(i).ready || tcdm_req_ready_reg(i)
+  }
+
+  tcdm_req_all_ready := tcdm_req_ready.reduce(_ & _)
+  ready_for_new_tcdm_reqs := !wait_for_tcdm_req_all_ready && can_send_tcdm_req
+
+  // signal indicating a new address data transaction is ready
+  io.ptr_agu_i.ready := cstate === sBUSY && ready_for_new_tcdm_reqs
+
+  // signal for indicating ready for new config
+  io.spatialStrides_csr_i.ready := cstate === sIDLE
+
+}

--- a/src/main/scala/streamer/DataReader.scala
+++ b/src/main/scala/streamer/DataReader.scala
@@ -5,25 +5,12 @@ import chisel3.util._
 
 // input and output for data reader (data mover in read mode)
 class DataReaderIO(
-    params: DataMoverParams
-) extends Bundle {
-
-  // signals for read request address generation
-  val ptr_agu_i = Flipped(Decoupled(UInt(params.addrWidth.W)))
-  val spatialStrides_csr_i = Flipped(
-    Decoupled(Vec(params.spatialDim, UInt(params.addrWidth.W)))
-  )
-
-  // tcdm read req
-  val tcdm_req_addr = Output(Vec(params.tcdmPortsNum, UInt(params.addrWidth.W)))
-  val read_tcmd_valid_o = Output(Vec(params.tcdmPortsNum, Bool()))
-
-  val tcdm_ready_i = Input(Vec(params.tcdmPortsNum, Bool()))
+    params: DataMoverParams = DataMoverParams()
+) extends DataMoverIO(params) {
 
   // tcdm rsp
-  val data_tcdm_i = Flipped(
-    (Vec(params.tcdmPortsNum, Valid(UInt(params.tcdmDataWidth.W))))
-  )
+  val tcdm_rsp =
+    Vec(params.tcdmPortsNum, Flipped(Valid(new TcdmRsp(params.tcdmDataWidth))))
 
   // data pushed into the queue
   val data_fifo_o = Decoupled(UInt(params.fifoWidth.W))
@@ -33,70 +20,28 @@ class DataReaderIO(
     "fifoWidth should match with TCDM datawidth for now!"
   )
 
-  // from temporal address generation unit to indicate if the transaction is done
-  val done = Input(Bool())
-
 }
 
 // data reader, for sending read request to TCDM and collect data from TCDM response, pushing valid data into the queue
 // data producer from the accelerator X aspect
 class DataReader(
     params: DataMoverParams = DataMoverParams()
-) extends Module
-    with RequireAsyncReset {
+) extends DataMover(params) {
 
-  val io = IO(
-    new DataReaderIO(
-      params
-    )
-  )
-
-  // storing the temporal start address when it is valid
-  val ptr_agu = RegInit(0.U(params.addrWidth.W))
-  val start_ptr = WireInit(0.U(params.addrWidth.W))
-
-  // config valid signal for unrolling strides
-  // storing the config when it is valid
-  val config_valid = WireInit(0.B)
-  val unrollingStrides = RegInit(
-    VecInit(Seq.fill(params.spatialDim)(0.U(params.addrWidth.W)))
-  )
-
-  // original unrolling address for TCDM request
-  val unrolling_addr = WireInit(
-    VecInit(
-      Seq.fill(params.spatialBounds.reduce(_ * _))(0.U(params.addrWidth.W))
-    )
-  )
-
-  // for selecting the real TCDM request address from the original unrolling addresses
-  // according to the tcdmDataWidth and the elementWidth relationship
-  // !!! warning: assuming the data granularity is one tcdmDataWidth
-  // no sub-data accessing within one TCDM bank
-  def packed_addr_num = (params.tcdmDataWidth / 8) / (params.elementWidth / 8)
+  override lazy val io = IO(new DataReaderIO(params))
+  io.suggestName("io")
 
   // Fifo input signals
   val fifo_input_bits = WireInit(0.U(params.fifoWidth.W))
   val fifo_input_valid = WireInit(0.B)
 
-  // not in the busy with sending current request process
-  val ready_for_new_tcdm_reqs = WireInit(0.B)
-  // data fifo isn't full
-  val can_send_tcdm_read_req = WireInit(0.B)
-  // means transaction success
-  val tcdm_read_mem_all_ready = WireInit(0.B)
-
   // signals for dealing with contention
-  val tcdm_rsp_i_p_valid = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
-  val tcdm_rsp_i_p_valid_reg = RegInit(
+  val tcdm_rsp_valid = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
+  val tcdm_rsp_valid_reg = RegInit(
     VecInit(Seq.fill(params.tcdmPortsNum)(0.B))
   )
-  val tcdm_rsp_i_q_ready = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
-  val tcdm_rsp_i_q_ready_reg = RegInit(
-    VecInit(Seq.fill(params.tcdmPortsNum)(0.B))
-  )
-  val wait_for_q_ready_read = WireInit(0.B)
-  val wait_for_p_valid_read = WireInit(0.B)
+
+  val wait_for_tcdm_rsp_all_valid = WireInit(0.B)
 
   // storing response data (part of whole transaction) when waiting for other part
   val data_reg = RegInit(
@@ -106,144 +51,38 @@ class DataReader(
     VecInit(Seq.fill(params.tcdmPortsNum)(0.U(params.tcdmDataWidth.W)))
   )
 
-  // State declaration
-  val sIDLE :: sBUSY :: Nil = Enum(2)
-  val cstate = RegInit(sIDLE)
-  val nstate = WireInit(sIDLE)
-
-  // Changing states
-  cstate := nstate
-
-  chisel3.dontTouch(cstate)
-  switch(cstate) {
-    is(sIDLE) {
-      when(config_valid) {
-        nstate := sBUSY
-      }.otherwise {
-        nstate := sIDLE
-      }
-
-    }
-    is(sBUSY) {
-      when(io.done) {
-        nstate := sIDLE
-      }.otherwise {
-        nstate := sBUSY
-      }
-    }
-  }
-
-  // store them for later use
-  when(config_valid) {
-    unrollingStrides := io.spatialStrides_csr_i.bits
-  }
-
-  config_valid := io.spatialStrides_csr_i.fire
-
-  start_ptr := io.ptr_agu_i.bits
-
-  // generating original unrolling address for TCDM request
-  val spatial_addr_gen_unit = Module(
-    new SpatialAddrGenUnit(
-      SpatialAddrGenUnitParams(
-        params.spatialDim,
-        params.spatialBounds,
-        params.addrWidth
-      )
-    )
-  )
-
-  spatial_addr_gen_unit.io.valid_i := cstate =/= sIDLE
-  spatial_addr_gen_unit.io.ptr_i := start_ptr
-  spatial_addr_gen_unit.io.strides_i := unrollingStrides
-  unrolling_addr := spatial_addr_gen_unit.io.ptr_o
-
-  // simulation time address constraint check
-  when(cstate === sBUSY) {
-    for (i <- 0 until params.tcdmPortsNum) {
-      for (j <- 0 until packed_addr_num - 1) {
-        assert(
-          unrolling_addr(i * packed_addr_num + j + 1) === unrolling_addr(
-            i * packed_addr_num + j
-          ) + ((params.tcdmDataWidth / 8) / packed_addr_num).U,
-          "read address in not consecutive in the same bank!"
-        )
-      }
-    }
-  }
-
-  can_send_tcdm_read_req := io.data_fifo_o.ready && cstate === sBUSY
-
-  // assuming addresses are packed in one tcmd request
-  // the data granularity constrain
-  for (i <- 0 until params.tcdmPortsNum) {
-    io.tcdm_req_addr(i) := unrolling_addr(i * packed_addr_num)
-  }
-
-  // deal with contention
-  // ensure all the read request are sent successfully
-  for (i <- 0 until params.tcdmPortsNum) {
-    when(can_send_tcdm_read_req) {
-      when(io.ptr_agu_i.fire) {
-        io.read_tcmd_valid_o(i) := 1.B
-      }.otherwise {
-        io.read_tcmd_valid_o(i) := ~tcdm_rsp_i_q_ready_reg(i)
-      }
-    }.otherwise {
-      io.read_tcmd_valid_o(i) := 0.B
-    }
-  }
-
-  for (i <- 0 until params.tcdmPortsNum) {
-    when(can_send_tcdm_read_req && !tcdm_read_mem_all_ready) {
-      wait_for_q_ready_read := 1.B
-    }.otherwise {
-      wait_for_q_ready_read := 0.B
-    }
-  }
-
-  for (i <- 0 until params.tcdmPortsNum) {
-    when(wait_for_q_ready_read && !tcdm_read_mem_all_ready) {
-      when(io.tcdm_ready_i(i)) {
-        tcdm_rsp_i_q_ready_reg(i) := io.tcdm_ready_i(i)
-      }
-    }.otherwise {
-      tcdm_rsp_i_q_ready_reg(i) := 0.B
-    }
-  }
-
-  for (i <- 0 until params.tcdmPortsNum) {
-    tcdm_rsp_i_q_ready(i) := io.tcdm_ready_i(i) || tcdm_rsp_i_q_ready_reg(i)
-  }
-
-  tcdm_read_mem_all_ready := tcdm_rsp_i_q_ready.reduce(_ & _)
-  ready_for_new_tcdm_reqs := !wait_for_q_ready_read && can_send_tcdm_read_req
+  can_send_tcdm_req := io.data_fifo_o.ready && cstate === sBUSY
 
   // check and wait for all the response valid
   for (i <- 0 until params.tcdmPortsNum) {
-    when(can_send_tcdm_read_req && !fifo_input_valid) {
-      wait_for_p_valid_read := 1.B
+    when(can_send_tcdm_req && !fifo_input_valid) {
+      wait_for_tcdm_rsp_all_valid := 1.B
     }.otherwise {
-      wait_for_p_valid_read := 0.B
+      wait_for_tcdm_rsp_all_valid := 0.B
     }
   }
 
   for (i <- 0 until params.tcdmPortsNum) {
-    when(wait_for_p_valid_read && !fifo_input_valid) {
-      when(io.data_tcdm_i(i).valid) {
-        tcdm_rsp_i_p_valid_reg(i) := io.data_tcdm_i(i).valid
-        data_reg(i) := io.data_tcdm_i(i).bits
+    io.tcdm_req(i).bits.data := 0.U
+    io.tcdm_req(i).bits.write := 0.U
+  }
+
+  for (i <- 0 until params.tcdmPortsNum) {
+    when(wait_for_tcdm_rsp_all_valid && !fifo_input_valid) {
+      when(io.tcdm_rsp(i).valid) {
+        tcdm_rsp_valid_reg(i) := io.tcdm_rsp(i).valid
+        data_reg(i) := io.tcdm_rsp(i).bits.data
       }
     }.otherwise {
-      tcdm_rsp_i_p_valid_reg(i) := 0.B
+      tcdm_rsp_valid_reg(i) := 0.B
     }
   }
 
   // fifo data
   for (i <- 0 until params.tcdmPortsNum) {
     when(fifo_input_valid) {
-      when(io.data_tcdm_i(i).valid) {
-        data_fifo_input(i) := io.data_tcdm_i(i).bits
+      when(io.tcdm_rsp(i).valid) {
+        data_fifo_input(i) := io.tcdm_rsp(i).bits.data
       }.otherwise {
         data_fifo_input(i) := data_reg(i)
       }
@@ -254,18 +93,10 @@ class DataReader(
 
   // fifo valid
   for (i <- 0 until params.tcdmPortsNum) {
-    tcdm_rsp_i_p_valid(i) := io.data_tcdm_i(i).valid || tcdm_rsp_i_p_valid_reg(
-      i
-    )
+    tcdm_rsp_valid(i) := io.tcdm_rsp(i).valid || tcdm_rsp_valid_reg(i)
   }
-  fifo_input_valid := tcdm_rsp_i_p_valid.reduce(_ & _)
+  fifo_input_valid := tcdm_rsp_valid.reduce(_ & _)
   io.data_fifo_o.valid := fifo_input_valid
-
-  // signal indicating a new address data transaction is ready
-  io.ptr_agu_i.ready := cstate === sBUSY && ready_for_new_tcdm_reqs
-
-  // signal for indicating ready for new config
-  io.spatialStrides_csr_i.ready := cstate === sIDLE
 
 }
 

--- a/src/main/scala/streamer/DataReader.scala
+++ b/src/main/scala/streamer/DataReader.scala
@@ -3,7 +3,12 @@ package streamer
 import chisel3._
 import chisel3.util._
 
-// input and output for data reader (data mover in read mode)
+/** This class is input and output for data reader (data mover in read mode). It
+  * is extended from DataMoverIO. It adds tcdm_rsp input ports and fifo output
+  * ports.
+  * @param params
+  *   The parameter class contains all the parameters of a data mover module
+  */
 class DataReaderIO(
     params: DataMoverParams = DataMoverParams()
 ) extends DataMoverIO(params) {
@@ -22,25 +27,27 @@ class DataReaderIO(
 
 }
 
-// data reader, for sending read request to TCDM and collect data from TCDM response, pushing valid data into the queue
-// data producer from the accelerator X aspect
+/** This class is data reader module,.It is responsible for sending read request
+  * to TCDM and collect data from TCDM response, pushing valid data into the
+  * queue It is the data producer from the accelerator X aspect. It extends from
+  * the DataMover and add extract waiting and collecting tcdm response logic,
+  * fifo output logic.
+  * @param params
+  *   The parameter class contains all the parameters of a data mover module
+  */
 class DataReader(
     params: DataMoverParams = DataMoverParams()
 ) extends DataMover(params) {
 
+  // override the IO of DataMover
   override lazy val io = IO(new DataReaderIO(params))
   io.suggestName("io")
-
-  // Fifo input signals
-  val fifo_input_bits = WireInit(0.U(params.fifoWidth.W))
-  val fifo_input_valid = WireInit(0.B)
 
   // signals for dealing with contention
   val tcdm_rsp_valid = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
   val tcdm_rsp_valid_reg = RegInit(
     VecInit(Seq.fill(params.tcdmPortsNum)(0.B))
   )
-
   val wait_for_tcdm_rsp_all_valid = WireInit(0.B)
 
   // storing response data (part of whole transaction) when waiting for other part
@@ -51,9 +58,20 @@ class DataReader(
     VecInit(Seq.fill(params.tcdmPortsNum)(0.U(params.tcdmDataWidth.W)))
   )
 
+  // Fifo input signals
+  val fifo_input_bits = WireInit(0.U(params.fifoWidth.W))
+  val fifo_input_valid = WireInit(0.B)
+
+  // when read data fifo isn't full means can send tcdm request to read (prefetch) more data
   can_send_tcdm_req := io.data_fifo_o.ready && cstate === sBUSY
 
-  // check and wait for all the response valid
+  // data and write signal is 0 for read request
+  for (i <- 0 until params.tcdmPortsNum) {
+    io.tcdm_req(i).bits.data := 0.U
+    io.tcdm_req(i).bits.write := 0.B
+  }
+
+  // check and wait for all the response valid (similar as checking request ready)
   for (i <- 0 until params.tcdmPortsNum) {
     when(can_send_tcdm_req && !fifo_input_valid) {
       wait_for_tcdm_rsp_all_valid := 1.B
@@ -63,22 +81,20 @@ class DataReader(
   }
 
   for (i <- 0 until params.tcdmPortsNum) {
-    io.tcdm_req(i).bits.data := 0.U
-    io.tcdm_req(i).bits.write := 0.U
-  }
-
-  for (i <- 0 until params.tcdmPortsNum) {
     when(wait_for_tcdm_rsp_all_valid && !fifo_input_valid) {
       when(io.tcdm_rsp(i).valid) {
         tcdm_rsp_valid_reg(i) := io.tcdm_rsp(i).valid
         data_reg(i) := io.tcdm_rsp(i).bits.data
       }
     }.otherwise {
+      // clear all the valid bits before a new transaction
       tcdm_rsp_valid_reg(i) := 0.B
     }
   }
 
   // fifo data
+  // getting data directly from the response ports or the data register depends on
+  // if response valid at the all response is valid moment
   for (i <- 0 until params.tcdmPortsNum) {
     when(fifo_input_valid) {
       when(io.tcdm_rsp(i).valid) {
@@ -88,6 +104,8 @@ class DataReader(
       }
     }
   }
+
+  // gether all the response data
   fifo_input_bits := Cat(data_fifo_input)
   io.data_fifo_o.bits := fifo_input_bits
 
@@ -95,6 +113,7 @@ class DataReader(
   for (i <- 0 until params.tcdmPortsNum) {
     tcdm_rsp_valid(i) := io.tcdm_rsp(i).valid || tcdm_rsp_valid_reg(i)
   }
+  // write the responded data to the fifo when all the data is valid
   fifo_input_valid := tcdm_rsp_valid.reduce(_ & _)
   io.data_fifo_o.valid := fifo_input_valid
 

--- a/src/main/scala/streamer/DataWriter.scala
+++ b/src/main/scala/streamer/DataWriter.scala
@@ -5,14 +5,8 @@ import chisel3.util._
 
 // input and output for data writer (data mover in write mode)
 class DataWriterIO(
-    params: DataMoverParams
-) extends Bundle {
-
-  // signals for write request address generation
-  val ptr_agu_i = Flipped(Decoupled(UInt(params.addrWidth.W)))
-  val spatialStrides_csr_i = Flipped(
-    Decoupled(Vec(params.spatialDim, UInt(params.addrWidth.W)))
-  )
+    params: DataMoverParams = DataMoverParams()
+) extends DataMoverIO(params) {
 
   // valid data from the queue
   val data_fifo_i = Flipped(Decoupled(UInt(params.fifoWidth.W)))
@@ -22,193 +16,35 @@ class DataWriterIO(
     "params.fifoWidth should match with TCDM datawidth for now!"
   )
 
-  // tcdm write req signals
-  val tcdm_req_addr = Output(Vec(params.tcdmPortsNum, UInt(params.addrWidth.W)))
-  val write_tcmd_valid_o = Output(Vec(params.tcdmPortsNum, Bool()))
-  val tcdm_req_data = Output(
-    Vec(params.tcdmPortsNum, UInt(params.tcdmDataWidth.W))
-  )
-
-  val tcdm_ready_i = Input(Vec(params.tcdmPortsNum, Bool()))
-
-  // from temporal address generation unit to indicate if the transaction is done
-  val done = Input(Bool())
-
 }
 
 // data writer, for sending write request to TCDM, getting valid data from the queue
 // data consumer from the accelerator X aspect
 class DataWriter(
     params: DataMoverParams = DataMoverParams()
-) extends Module
-    with RequireAsyncReset {
+) extends DataMover(params) {
 
-  val io = IO(
-    new DataWriterIO(
-      params
-    )
-  )
+  override lazy val io = IO(new DataWriterIO(params))
+  io.suggestName("io")
 
-  // storing the temporal start address when it is valid
-  val ptr_agu = RegInit(0.U(params.addrWidth.W))
-  val start_ptr = WireInit(0.U(params.addrWidth.W))
-
-  // config valid signal for unrolling strides
-  // storing the config when it is valid
-  val config_valid = WireInit(0.B)
-  val unrollingStrides = RegInit(
-    VecInit(Seq.fill(params.spatialDim)(0.U(params.addrWidth.W)))
-  )
-
-  // original unrolling address for TCDM request
-  val unrolling_addr = WireInit(
-    VecInit(
-      Seq.fill(params.spatialBounds.reduce(_ * _))(0.U(params.addrWidth.W))
-    )
-  )
-
-  // for selecting the real TCDM request address from the original unrolling addresses
-  // according to the params.tcdmDataWidth and the elementWidth relationship
-  // !!! warning: assuming the data granularity is one params.tcdmDataWidth
-  // no sub-data accessing within one TCDM bank
-  def packed_addr_num = (params.tcdmDataWidth / 8) / (params.elementWidth / 8)
-
-  val tcdm_rsp_i_q_ready = WireInit(VecInit(Seq.fill(params.tcdmPortsNum)(0.B)))
-  val tcdm_rsp_i_q_ready_reg = RegInit(
-    VecInit(Seq.fill(params.tcdmPortsNum)(0.B))
-  )
-  val wait_for_q_ready_write = WireInit(0.B)
-
-  val can_send_tcdm_write_req = WireInit(0.B)
-  val ready_for_new_tcdm_reqs = WireInit(0.B)
-  val tcdm_write_mem_all_ready = WireInit(0.B)
-
-  // State declaration
-  val sIDLE :: sBUSY :: Nil = Enum(2)
-  val cstate = RegInit(sIDLE)
-  val nstate = WireInit(sIDLE)
-
-  // Changing states
-  cstate := nstate
-
-  chisel3.dontTouch(cstate)
-  switch(cstate) {
-    is(sIDLE) {
-      when(config_valid) {
-        nstate := sBUSY
-      }.otherwise {
-        nstate := sIDLE
-      }
-
-    }
-    is(sBUSY) {
-      when(io.done) {
-        nstate := sIDLE
-      }.otherwise {
-        nstate := sBUSY
-      }
-    }
-  }
-
-  // store them for later use
-  when(config_valid) {
-    unrollingStrides := io.spatialStrides_csr_i.bits
-  }
-
-  config_valid := io.spatialStrides_csr_i.fire
-
-  start_ptr := io.ptr_agu_i.bits
-
-  // generating original unrolling address for TCDM request
-  val spatial_addr_gen_unit = Module(
-    new SpatialAddrGenUnit(
-      SpatialAddrGenUnitParams(
-        params.spatialDim,
-        params.spatialBounds,
-        params.addrWidth
-      )
-    )
-  )
-
-  spatial_addr_gen_unit.io.valid_i := cstate =/= sIDLE
-  spatial_addr_gen_unit.io.ptr_i := start_ptr
-  spatial_addr_gen_unit.io.strides_i := unrollingStrides
-  unrolling_addr := spatial_addr_gen_unit.io.ptr_o
-
-  // address constraint check
-  when(cstate === sBUSY) {
-    for (i <- 0 until params.tcdmPortsNum) {
-      for (j <- 0 until packed_addr_num - 1) {
-        assert(
-          unrolling_addr(i * packed_addr_num + j + 1) === unrolling_addr(
-            i * packed_addr_num + j
-          ) + ((params.tcdmDataWidth / 8) / packed_addr_num).U,
-          "write address in not consecutive in the same bank!"
-        )
-      }
-    }
-  }
-
-  can_send_tcdm_write_req := io.data_fifo_i.valid && cstate === sBUSY
-
-  // assuming addresses are packed in one tcmd request
-  for (i <- 0 until params.tcdmPortsNum) {
-    io.tcdm_req_addr(i) := unrolling_addr(i * packed_addr_num)
-  }
+  can_send_tcdm_req := io.data_fifo_i.valid && cstate === sBUSY
 
   // deal with contention
   // ensure all the write request are sent successfully
   for (i <- 0 until params.tcdmPortsNum) {
-    when(can_send_tcdm_write_req) {
-      when(io.ptr_agu_i.fire) {
-        io.write_tcmd_valid_o(i) := 1.B
-      }.otherwise {
-        io.write_tcmd_valid_o(i) := ~tcdm_rsp_i_q_ready_reg(i)
-      }
-      io.tcdm_req_data(i) := io.data_fifo_i.bits(
+    when(can_send_tcdm_req) {
+      io.tcdm_req(i).bits.data := io.data_fifo_i.bits(
         (i + 1) * params.tcdmDataWidth - 1,
         i * params.tcdmDataWidth
       )
     }.otherwise {
-      io.write_tcmd_valid_o(i) := 0.B
-      io.tcdm_req_data(i) := 0.U
+      io.tcdm_req(i).bits.data := 0.U
     }
+    io.tcdm_req(i).bits.write := 1.U
   }
-
-  for (i <- 0 until params.tcdmPortsNum) {
-    when(can_send_tcdm_write_req && !tcdm_write_mem_all_ready) {
-      wait_for_q_ready_write := 1.B
-    }.otherwise {
-      wait_for_q_ready_write := 0.B
-    }
-  }
-
-  // ensure getting all the grants
-  for (i <- 0 until params.tcdmPortsNum) {
-    when(wait_for_q_ready_write && !tcdm_write_mem_all_ready) {
-      when(io.tcdm_ready_i(i)) {
-        tcdm_rsp_i_q_ready_reg(i) := io.tcdm_ready_i(i)
-      }
-    }.otherwise {
-      tcdm_rsp_i_q_ready_reg(i) := 0.B
-    }
-  }
-
-  for (i <- 0 until params.tcdmPortsNum) {
-    tcdm_rsp_i_q_ready(i) := io.tcdm_ready_i(i) || tcdm_rsp_i_q_ready_reg(i)
-  }
-
-  tcdm_write_mem_all_ready := tcdm_rsp_i_q_ready.reduce(_ & _)
-  ready_for_new_tcdm_reqs := !wait_for_q_ready_write && can_send_tcdm_write_req
-
-  // signal indicating new address data transaction is ready
-  io.ptr_agu_i.ready := cstate === sBUSY && ready_for_new_tcdm_reqs
-
-  // signal for indicating ready for new config
-  io.spatialStrides_csr_i.ready := cstate === sIDLE
 
   // ready signal for data queue
-  io.data_fifo_i.ready := tcdm_write_mem_all_ready
+  io.data_fifo_i.ready := tcdm_req_all_ready
 
 }
 

--- a/src/main/scala/streamer/Parameters.scala
+++ b/src/main/scala/streamer/Parameters.scala
@@ -58,7 +58,7 @@ case class SpatialAddrGenUnitParams(
   *   mover
   * @param elementWidth
   *   single data element width for each data mover, useful for generating
-  *   unrolling addresses
+  *   spatial addresses
   * @param fifoWidth
   *   FIFO width
   */
@@ -116,8 +116,7 @@ trait HasStreamerCoreParams {
   * @param temporalBoundWidth
   *   the register width for storing the temporal loop bound
   * @param spatialDim
-  *   a Seq contains the unrolling dimensions for both data reader and data
-  *   writer
+  *   a Seq contains the spatial dimensions for both data reader and data writer
   * @param tcdmDataWidth
   *   data width for each TCDm port
   * @param addrWidth

--- a/src/main/scala/streamer/SpatialAddrGenUnit.scala
+++ b/src/main/scala/streamer/SpatialAddrGenUnit.scala
@@ -35,7 +35,7 @@ class SpatialAddrGenUnitIO(
     params: SpatialAddrGenUnitParams
 ) extends Bundle {
 
-  // configurations for unrolling address generation
+  // configurations for spatial address generation
   val valid_i = Input(Bool())
   val ptr_i = Input(UInt(params.addrWidth.W))
   val strides_i = Input(Vec(params.loopDim, UInt(params.addrWidth.W)))
@@ -49,7 +49,7 @@ class SpatialAddrGenUnitIO(
 // a trait other class can extend to have the genSpatialLoopIndices function
 trait WithSpatialLoopIndices {
 
-  // a scala function to generate the nested indices of the unrolled loop counter for generating unrolling addresses
+  // a scala function to generate the nested indices of the unrolled loop counter for generating spatial addresses
   // for instance:
   // genSpatialLoopIndices(2,Seq(8,8),0) returns (0,0)
   // genSpatialLoopIndices(2,Seq(8,8),1) returns (1,0)
@@ -126,11 +126,11 @@ class SpatialAddrGenUnit(
     )
 
     when(valid) {
-      // address generation for each unrolling data element
+      // address generation for each spatial data element
       // will ignore some later to be aligned with bank width
       for (i <- 0 until loopBounds.product) {
 
-        // indices for each nested unrolling loop
+        // indices for each nested spatial loop
         val indices = genSpatialLoopIndices(loopDim, loopBounds, i)
 
         // address generation with affine mapping definition

--- a/src/test/scala/streamer/DataReaderTest.scala
+++ b/src/test/scala/streamer/DataReaderTest.scala
@@ -18,7 +18,7 @@ class DataReaderTest
       Seq(WriteVcdAnnotation)
     ) { dut =>
       dut.clock.step(5)
-      // give valid config, give the proper unrolling strides so that is a aligned in one TCDM bank
+      // give valid config, give the proper spatial strides so that is a aligned in one TCDM bank
       dut.io.spatialStrides_csr_i.bits(0).poke(1)
       dut.io.spatialStrides_csr_i.bits(1).poke(8)
       dut.io.spatialStrides_csr_i.valid.poke(1)

--- a/src/test/scala/streamer/DataReaderTest.scala
+++ b/src/test/scala/streamer/DataReaderTest.scala
@@ -24,8 +24,8 @@ class DataReaderTest
       dut.io.spatialStrides_csr_i.valid.poke(1)
       dut.io.data_fifo_o.ready.poke(1)
       for (i <- 0 until DataMoverTestParameters.tcdmPortsNum) {
-        dut.io.tcdm_ready_i(i).poke(1)
-        dut.io.data_tcdm_i(i).valid.poke(1)
+        dut.io.tcdm_req(i).ready.poke(1)
+        dut.io.tcdm_rsp(i).bits.data.poke(1)
       }
       dut.clock.step(5)
       dut.io.spatialStrides_csr_i.valid.poke(0)

--- a/src/test/scala/streamer/DataWriterTest.scala
+++ b/src/test/scala/streamer/DataWriterTest.scala
@@ -18,7 +18,7 @@ class DataWriterTest
       Seq(WriteVcdAnnotation)
     ) { dut =>
       dut.clock.step(5)
-      // give valid config, give the proper unrolling strides so that is a aligned in one TCDM bank
+      // give valid config, give the proper spatial strides so that is a aligned in one TCDM bank
       dut.io.spatialStrides_csr_i.bits(0).poke(1)
       dut.io.spatialStrides_csr_i.bits(1).poke(8)
       dut.io.spatialStrides_csr_i.valid.poke(1)

--- a/src/test/scala/streamer/DataWriterTest.scala
+++ b/src/test/scala/streamer/DataWriterTest.scala
@@ -24,7 +24,7 @@ class DataWriterTest
       dut.io.spatialStrides_csr_i.valid.poke(1)
       dut.io.data_fifo_i.valid.poke(1)
       for (i <- 0 until DataMoverTestParameters.tcdmPortsNum) {
-        dut.io.tcdm_ready_i(i).poke(1)
+        dut.io.tcdm_req(i).ready.poke(1)
       }
       dut.clock.step(5)
       dut.io.spatialStrides_csr_i.valid.poke(0)

--- a/src/test/scala/streamer/SpatialAddrGenUnitTest.scala
+++ b/src/test/scala/streamer/SpatialAddrGenUnitTest.scala
@@ -7,7 +7,7 @@ import scala.math.BigInt
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Tag
 
-// manual test for unrolling address generation unit
+// manual test for spatial address generation unit
 // TODO: automated random configuration test and automated results check
 class SpatialAddrGenUnitTest
     extends AnyFlatSpec

--- a/src/test/scala/streamer/StreamerTest.scala
+++ b/src/test/scala/streamer/StreamerTest.scala
@@ -24,7 +24,7 @@ class StreamerTest
           dut.io.csr.bits.loopBounds_i(i).poke(2)
         }
 
-        // give the proper unrolling strides so that is a aligned in one TCDM bank
+        // give the proper spatial strides so that is a aligned in one TCDM bank
         for (i <- 0 until StreamerParams().dataMoverNum) {
           dut.io.csr.bits.spatialStrides_csr_i(i)(0).poke(4)
         }

--- a/src/test/scala/streamer/StreamerTopTest.scala
+++ b/src/test/scala/streamer/StreamerTopTest.scala
@@ -80,7 +80,7 @@ class StreamerTopTest
         write_csr(4, 2)
 
         // spatial loop strides
-        // warning!!! give the proper unrolling strides so that is a aligned in one TCDM bank.
+        // warning!!! give the proper spatial strides so that is a aligned in one TCDM bank.
         // address 5 configs the spatial loop stride for first data reader, which is a_u for mac engine.
         write_csr(5, 4)
         // address 6 configs the spatial loop stride for second data reader, which is b_u for mac engine.


### PR DESCRIPTION
In this PR, we refactor the data reader and data writer, specifically,
* create a new class datamoverIO that presents the common ports of both data reader and writer, and based on it, create class DataReaderIO and DataWriterIO.
* create a new class datamover that presents the common features of both data reader and writer, and based on it, create class data reader and writer.
* relevant change to the ports connection inside streamer module.
* rename some signals to make them reusable for both reader and writer.
* signal names in tests also changed
* rename unrolling2spatial