### PR TITLE
refactor csr manager and add test

### DIFF
--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -40,7 +40,7 @@ class CsrManager(
   // generate a vector of registers to store the csr state
   val csr = RegInit(VecInit(Seq.fill(csrNum)(0.U(32.W))))
 
-  // read write and start csr commandd
+  // read write and start csr command
   val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
   val write_csr = io.csr_config_in.req.fire && io.csr_config_in.req.bits.write
   val start_csr = io.csr_config_in.req.bits.write &&

--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -60,10 +60,9 @@ class CsrManager(
   // is busy (ready not asserted), store the read result in a buffer.
 
   // signal to indicate if a read request is in progress
-  val read_csr_busy = RegNext(
-    io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
-  )
-
+  val read_csr_busy = RegInit(0.B)
+  read_csr_busy := io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
+    
   // a register to buffer the read request response data until the request is finished
   val read_csr_buffer = RegInit(0.U(32.W))
   read_csr_buffer := io.csr_config_in.rsp.bits.data

--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -62,7 +62,7 @@ class CsrManager(
   // signal to indicate if a read request is in progress
   val read_csr_busy = RegInit(0.B)
   read_csr_busy := io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
-    
+
   // a register to buffer the read request response data until the request is finished
   val read_csr_buffer = RegInit(0.U(32.W))
   read_csr_buffer := io.csr_config_in.rsp.bits.data

--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -18,8 +18,6 @@ class CsrManagerIO(
 
   val csr_config_in = new StreamerTopCsrIO(csrAddrWidth)
   val csr_config_out = Decoupled(Vec(csrNum, UInt(32.W)))
-
-  val streamerBusy2Idle = Input(Bool())
 }
 
 /** This class represents the CsrManager module. It contains the csr registers
@@ -42,70 +40,65 @@ class CsrManager(
   // generate a vector of registers to store the csr state
   val csr = RegInit(VecInit(Seq.fill(csrNum)(0.U(32.W))))
 
-  // read and write csr cmd
+  // read write and start csr commandd
   val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
-  // streamerBusy2Idle has higher priority than the host request
-  val write_csr =
-    (io.csr_config_in.req.fire || io.streamerBusy2Idle) && io.csr_config_in.req.bits.write
+  val write_csr = io.csr_config_in.req.fire && io.csr_config_in.req.bits.write
+  val start_csr = io.csr_config_in.req.bits.write &&
+    (io.csr_config_in.req.bits.addr === (csrNum - 1).U) && io.csr_config_in.req.bits.data === 1.U
 
-  // keep sending response to a read request until we receive the response ready signal
-  val keep_sending_csr_rsp = RegInit(0.B)
-  keep_sending_csr_rsp := io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
-
-  // a register to store the read request response data until the request is successful
-  val csr_rsp_data_reg = RegInit(0.U(32.W))
-
-  // store the csr data for later output because the address only valid when io.csr.fire
-  csr_rsp_data_reg := Mux(
-    read_csr,
-    csr(io.csr_config_in.req.bits.addr),
-    csr_rsp_data_reg
-  )
-
-  // streamer configuration valid signal
-  val config_valid = WireInit(0.B)
-
-  // check if the csr address overflow (access certain csr that doesn't exist)
-  def startCsrAddr = (csrNum - 1).U
-
+  // assert the csr address is valid
   when(io.csr_config_in.req.fire) {
-
-    assert(
-      io.csr_config_in.req.bits.addr <= startCsrAddr,
-      "csr address overflow!"
-    )
-
+    assert(io.csr_config_in.req.bits.addr < csrNum.U, "csr address overflow!")
   }
 
-  // write req
+  // handle write req
   when(write_csr) {
     csr(io.csr_config_in.req.bits.addr) := io.csr_config_in.req.bits.data
   }
 
-  // handle read requests: keep sending response data until the request succeeds
+  // handle read requests: send the result directly. If the receiver
+  // is busy (ready not asserted), store the read result in a buffer.
+
+  // signal to indicate if a read request is in progress
+  val read_csr_busy = RegNext(
+    io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
+  )
+
+  // a register to buffer the read request response data until the request is finished
+  val read_csr_buffer = RegInit(0.U(32.W))
+  read_csr_buffer := io.csr_config_in.rsp.bits.data
+
   when(read_csr) {
     io.csr_config_in.rsp.bits.data := csr(io.csr_config_in.req.bits.addr)
     io.csr_config_in.rsp.valid := 1.B
-  }.elsewhen(keep_sending_csr_rsp) {
-    io.csr_config_in.rsp.bits.data := csr_rsp_data_reg
+  }.elsewhen(read_csr_busy) {
+    io.csr_config_in.rsp.bits.data := read_csr_buffer
     io.csr_config_in.rsp.valid := 1.B
   }.otherwise {
     io.csr_config_in.rsp.valid := 0.B
     io.csr_config_in.rsp.bits.data := 0.U
   }
 
-  // we are ready for a new request if two conditions hold:
-  // if we write to the config_valid register (the last one), the streamer must not be busy (io.csr_config_out.ready)
-  // if there is a read request in progress, we only accept new write requests
-  // streamerBusy2Idle has higher priority than the host request
-  io.csr_config_in.req.ready := !io.streamerBusy2Idle && (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
+  // handle start requests: if the last csr is written to 1, the
+  // configuration can be sent to the streamer if it is not busy
 
-  // a write/read to the last csr means the config is valid
-  config_valid := io.csr_config_in.req.fire && (io.csr_config_in.req.bits.addr === startCsrAddr) && io.csr_config_in.req.bits.data === 1.U
+  // streamer configuration valid signal
+  io.csr_config_out.valid := write_csr && (io.csr_config_in.req.bits.addr === (csrNum - 1).U) && io.csr_config_in.req.bits.data === 1.U
+
+  // CSR Manager ready signal logic
+  // The CSR Manager is always ready except if:
+  //   - a read transaction is still happening
+  //   - the launch signal is asserted but the streamer is not ready
+  when(read_csr_busy) {
+    io.csr_config_in.req.ready := 0.B
+  }.elsewhen(start_csr) {
+    io.csr_config_in.req.ready := io.csr_config_out.ready
+  }.otherwise {
+    io.csr_config_in.req.ready := 1.B
+  }
 
   // signals connected to the output ports
   io.csr_config_out.bits <> csr
-  io.csr_config_out.valid <> config_valid
 
 }
 

--- a/src/main/scala/streamer/StreamerTop.scala
+++ b/src/main/scala/streamer/StreamerTop.scala
@@ -100,7 +100,7 @@ class StreamerTop(
   csr_manager.io.csr_config_in.req.bits := csr_config_in_req_bits
   io.csr.req.ready := csr_manager.io.csr_config_in.req.ready
 
-  csr_manager.io.streamerBusy2Idle := streamerBusy2Idle
+  // csr_manager.io.streamerBusy2Idle := streamerBusy2Idle
 
   // connect the streamer and csrManager output
   // control signals

--- a/src/test/scala/streamer/CsrManagerTest.scala
+++ b/src/test/scala/streamer/CsrManagerTest.scala
@@ -1,0 +1,237 @@
+package streamer
+
+import chisel3._ 
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import scala.math.BigInt
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Tag
+import scala.util.control.Breaks._
+
+class CsrManagerTest 
+extends AnyFlatSpec
+with ChiselScalatestTester
+with Matchers {
+
+    "DUT" should "pass" in {
+        test(new CsrManager(10, 32)).withAnnotations(Seq(WriteVcdAnnotation)) 
+        { dut =>
+
+            // ***********************************************************************
+            // Write values to the CSRs (valid)
+            // ***********************************************************************
+
+            // First write some values to the CSR:
+            // 1. Write 10 to address 1
+            // 2. Write 20 to address 2
+            // 3. Write 30 to address 3
+            // 4. Write 40 to address 4
+
+            dut.io.csr_config_in.req.valid.poke(1.B)
+
+
+            dut.io.csr_config_in.req.bits.data.poke(10.U)
+            dut.io.csr_config_in.req.bits.addr.poke(1.U)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.bits.data.poke(20.U)
+            dut.io.csr_config_in.req.bits.addr.poke(2.U)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.bits.data.poke(30.U)
+            dut.io.csr_config_in.req.bits.addr.poke(3.U)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.bits.data.poke(40.U)
+            dut.io.csr_config_in.req.bits.addr.poke(4.U)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.valid.poke(0.B)
+
+            dut.clock.step(5)
+
+            // ***********************************************************************
+            // Read values of the CSRs (valid)
+            // ***********************************************************************
+
+            // Read at address 1:
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(1.U)
+            dut.io.csr_config_in.rsp.ready.poke(1.B)
+
+            dut.clock.step(1)
+
+            // expect to read 10
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(10.U)
+
+
+            // Read at address 2:
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(2.U)
+
+            dut.clock.step(1)
+
+            // expect to read 20
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(20.U)
+
+
+            // Read at address 3:
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(3.U)
+
+            dut.clock.step(1)
+
+            // expect to read 30
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(30.U)
+
+            // Read at address 4:
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(4.U)
+
+            dut.clock.step(1)
+
+            // expect to read 40
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(40.U)
+
+            dut.io.csr_config_in.req.valid.poke(0.B)
+            dut.io.csr_config_in.rsp.ready.poke(0.B)
+
+            dut.clock.step(5)
+
+            // ***********************************************************************
+            // Write to the CSRs without asserting valid
+            // ***********************************************************************
+
+            // Write without asserting valid
+            dut.io.csr_config_in.req.bits.data.poke(0.U)
+            dut.io.csr_config_in.req.bits.addr.poke(1.U)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+
+            dut.clock.step(1)
+
+            // Now reading should still return the original value (10)
+
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(1.U)
+            dut.io.csr_config_in.rsp.ready.poke(1.B)
+
+            dut.clock.step(1)
+
+            // expect to read 10
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(10.U)
+
+            dut.io.csr_config_in.req.valid.poke(0.B)
+            dut.io.csr_config_in.rsp.ready.poke(0.B)
+
+            dut.clock.step(3)
+
+            // ***********************************************************************
+            // More Complex Reading: read without asserting ready directly
+            // ***********************************************************************     
+
+            // Read at address 1: (without ready)
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(1.U)
+            dut.io.csr_config_in.rsp.ready.poke(0.B)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.valid.poke(0.B)
+
+            dut.clock.step(3)
+
+            // response should still be valid now
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(10.U)
+
+            // the csr should not be ready to accept new requests
+            dut.io.csr_config_in.rsp.ready.expect(0.B)
+
+            // send a new request which should be ignored
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(0.B)
+            dut.io.csr_config_in.req.bits.addr.poke(2.U)
+
+            dut.clock.step(1)
+
+            dut.io.csr_config_in.req.valid.poke(0.B)
+
+            // wait even longer
+
+            dut.clock.step(2)
+
+            // response should still be valid now
+            dut.io.csr_config_in.rsp.valid.expect(1.B)
+            dut.io.csr_config_in.rsp.bits.data.expect(10.U)
+
+            // the csr should not be ready to accept new requests
+            dut.io.csr_config_in.rsp.ready.expect(0.B)
+
+            // assert ready
+            dut.io.csr_config_in.rsp.ready.poke(1.B)
+
+            dut.clock.step(1)
+
+            // response should no longer be valid
+            dut.io.csr_config_in.rsp.valid.expect(0.B)
+            // the csr should be ready to accept new requests
+            dut.io.csr_config_in.rsp.ready.expect(1.B)
+            
+            dut.clock.step(5)
+
+            // ***********************************************************************
+            // Test output mechanism of the CSR manager
+            // ***********************************************************************
+
+            dut.io.csr_config_out.valid.expect(0.B)
+
+            // set output ready to 0
+            dut.io.csr_config_out.ready.poke(0.B)
+
+            // write a 1 to the valid register
+            dut.io.csr_config_in.req.valid.poke(1.B)
+            dut.io.csr_config_in.req.bits.write.poke(1.B)
+            dut.io.csr_config_in.req.bits.addr.poke(9.U)
+            dut.io.csr_config_in.req.bits.data.poke(1.U)
+
+            dut.clock.step(1)
+
+            // expect valid out to still be 0, as accelerator is not ready
+            dut.io.csr_config_out.valid.expect(0.B)
+            dut.io.csr_config_in.req.ready.expect(0.B)
+
+            dut.clock.step(1)
+
+            // set output ready to 1
+            dut.io.csr_config_out.ready.poke(1.B)
+            dut.io.csr_config_in.req.ready.expect(1.B)
+
+            dut.clock.step(1)
+
+            // expect valid out to be 1
+            dut.io.csr_config_out.valid.expect(1.B)
+
+            dut.clock.step(5)
+
+        } 
+    }
+}


### PR DESCRIPTION
This PR adds a test case for the `CsrManager` class.
It also refactors the code to improve readability and simplicity.

One special case has been removed because I don't think it is necessary:
We can no longer write CSRs when there is a read transaction busy. I think allowing for this may result in some hard to debug errors.