### PR TITLE
Add perf counter

### DIFF
--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -19,6 +19,7 @@ class CsrManagerIO(
   val csr_config_in = new StreamerTopCsrIO(csrAddrWidth)
   val csr_config_out = Decoupled(Vec(csrNum, UInt(32.W)))
 
+  val streamerBusy2Idle = Input(Bool())
 }
 
 /** This class represents the CsrManager module. It contains the csr registers
@@ -43,7 +44,7 @@ class CsrManager(
 
   // read and write csr cmd
   val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
-  val write_csr = io.csr_config_in.req.fire && io.csr_config_in.req.bits.write
+  val write_csr = (io.csr_config_in.req.fire || io.streamerBusy2Idle) && io.csr_config_in.req.bits.write
 
   // keep sending response to a read request until we receive the response ready signal
   val keep_sending_csr_rsp = RegNext(
@@ -94,7 +95,7 @@ class CsrManager(
   // we are ready for a new request if two conditions hold:
   // if we write to the config_valid register (the last one), the streamer must not be busy (io.csr_config_out.ready)
   // if there is a read request in progress, we only accept new write requests
-  io.csr_config_in.req.ready := (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
+  io.csr_config_in.req.ready := !io.streamerBusy2Idle && (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
 
   // a write/read to the last csr means the config is valid
   config_valid := io.csr_config_in.req.fire && (io.csr_config_in.req.bits.addr === startCsrAddr) && io.csr_config_in.req.bits.data === 1.U

--- a/src/main/scala/streamer/CsrManager.scala
+++ b/src/main/scala/streamer/CsrManager.scala
@@ -44,7 +44,9 @@ class CsrManager(
 
   // read and write csr cmd
   val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
-  val write_csr = (io.csr_config_in.req.fire || io.streamerBusy2Idle) && io.csr_config_in.req.bits.write
+  // streamerBusy2Idle has higher priority than the host request
+  val write_csr =
+    (io.csr_config_in.req.fire || io.streamerBusy2Idle) && io.csr_config_in.req.bits.write
 
   // keep sending response to a read request until we receive the response ready signal
   val keep_sending_csr_rsp = RegNext(
@@ -95,6 +97,7 @@ class CsrManager(
   // we are ready for a new request if two conditions hold:
   // if we write to the config_valid register (the last one), the streamer must not be busy (io.csr_config_out.ready)
   // if there is a read request in progress, we only accept new write requests
+  // streamerBusy2Idle has higher priority than the host request
   io.csr_config_in.req.ready := !io.streamerBusy2Idle && (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
 
   // a write/read to the last csr means the config is valid

--- a/src/main/scala/streamer/Streamer.scala
+++ b/src/main/scala/streamer/Streamer.scala
@@ -88,6 +88,8 @@ class StreamerIO(
   val data = new StreamerDataIO(
     params
   )
+  
+  val busy_o = Output(Bool())
 }
 
 // streamer generator module
@@ -195,6 +197,8 @@ class Streamer(
     }
   }
 
+  io.busy_o := cstate === sBUSY
+  
   config_valid := io.csr.fire && io.csr.fire && io.csr.fire && io.csr.fire
 
   for (i <- 0 until params.dataMoverNum) {

--- a/src/main/scala/streamer/Streamer.scala
+++ b/src/main/scala/streamer/Streamer.scala
@@ -88,7 +88,7 @@ class StreamerIO(
   val data = new StreamerDataIO(
     params
   )
-  
+
   val busy_o = Output(Bool())
 }
 
@@ -198,7 +198,7 @@ class Streamer(
   }
 
   io.busy_o := cstate === sBUSY
-  
+
   config_valid := io.csr.fire && io.csr.fire && io.csr.fire && io.csr.fire
 
   for (i <- 0 until params.dataMoverNum) {

--- a/src/main/scala/streamer/StreamerTop.scala
+++ b/src/main/scala/streamer/StreamerTop.scala
@@ -77,22 +77,22 @@ class StreamerTop(
   val streamerIdle2Busy = WireInit(false.B)
   val streamerBusy2Idle = WireInit(false.B)
 
-  streamerIdle2Busy := streamer.io.busy_o && !RegNext(streamer.io.busy_o)    
-  streamerBusy2Idle := !streamer.io.busy_o && RegNext(streamer.io.busy_o)    
+  streamerIdle2Busy := streamer.io.busy_o && !RegNext(streamer.io.busy_o)
+  streamerBusy2Idle := !streamer.io.busy_o && RegNext(streamer.io.busy_o)
 
   val performance_counter = RegInit(0.U(32.W))
-  when(streamer.io.busy_o){
+  when(streamer.io.busy_o) {
     performance_counter := performance_counter + 1.U
-  }.elsewhen(streamerBusy2Idle){
+  }.elsewhen(streamerBusy2Idle) {
     performance_counter := 0.U
   }
 
   csr_config_in_req_valid := io.csr.req.valid
-  when(streamerBusy2Idle){
+  when(streamerBusy2Idle) {
     csr_config_in_req_bits.addr := csrNum.U - 2.U
     csr_config_in_req_bits.data := performance_counter
     csr_config_in_req_bits.write := true.B
-  }.otherwise{
+  }.otherwise {
     csr_config_in_req_bits := io.csr.req.bits
   }
 


### PR DESCRIPTION
This PR adds the performance counter for profiling. The performance counter is written into the specific CSR after the streamer is idle. And the performance counter written has higher priority than the host CSR request.